### PR TITLE
fix: miss indent after deleting item

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -38,7 +38,7 @@ export default class DB {
     let idx = items.findIndex(o => o.id == uid)
     if (idx !== -1) {
       items.splice(idx, 1)
-      await writeFile(this.file, JSON.stringify(items))
+      await writeFile(this.file, JSON.stringify(items, null, 2))
     }
   }
 }


### PR DESCRIPTION
fix: 在 CocList 中删除一项后，`yank.json` 文件会被压缩成一行